### PR TITLE
Refactor dense layers to PyTorch utilities

### DIFF
--- a/rnn.py
+++ b/rnn.py
@@ -12,7 +12,7 @@ from dataset import HandwritingDataset, handwriting_collate_fn
 from rnn_cell import LSTMAttentionCell
 from rnn_ops import rnn_free_run
 from tf_base_model import TFBaseModel
-from tf_utils import time_distributed_dense_layer
+from torch_utils import time_distributed_dense_layer
 
 
 class DataLoaders(object):
@@ -176,7 +176,7 @@ class rnn(TFBaseModel):
             initial_state=self.initial_state,
             scope='rnn'
         )
-        params = time_distributed_dense_layer(outputs, self.output_units, scope='rnn/gmm')
+        params = time_distributed_dense_layer(outputs, self.output_units)
         pis, mus, sigmas, rhos, es = self.parse_parameters(params)
         sequence_loss, self.loss = self.NLL(self.y, self.x_len, pis, mus, sigmas, rhos, es)
 

--- a/rnn_cell.py
+++ b/rnn_cell.py
@@ -4,7 +4,8 @@ import tensorflow as tf
 import tensorflow.contrib.distributions as tfd
 import numpy as np
 
-from tf_utils import dense_layer, shape
+from torch_utils import dense_layer
+from tf_utils import shape
 
 
 LSTMAttentionCellState = namedtuple(
@@ -82,7 +83,7 @@ class LSTMAttentionCell(tf.nn.rnn_cell.RNNCell):
 
             # attention
             attention_inputs = tf.concat([state.w, inputs, s1_out], axis=1)
-            attention_params = dense_layer(attention_inputs, 3*self.num_attn_mixture_components, scope='attention')
+            attention_params = dense_layer(attention_inputs, 3*self.num_attn_mixture_components)
             alpha, beta, kappa = tf.split(tf.nn.softplus(attention_params), 3, axis=1)
             kappa = state.kappa + kappa / 25.0
             beta = tf.clip_by_value(beta, .01, np.inf)
@@ -126,7 +127,7 @@ class LSTMAttentionCell(tf.nn.rnn_cell.RNNCell):
             return s3_out, new_state
 
     def output_function(self, state):
-        params = dense_layer(state.h3, self.output_units, scope='gmm', reuse=tf.AUTO_REUSE)
+        params = dense_layer(state.h3, self.output_units)
         pis, mus, sigmas, rhos, es = self._parse_parameters(params)
         mu1, mu2 = tf.split(mus, 2, axis=1)
         mus = tf.stack([mu1, mu2], axis=2)

--- a/torch_utils.py
+++ b/torch_utils.py
@@ -1,0 +1,52 @@
+import torch
+from torch import nn
+
+
+def dense_layer(inputs, out_features, activation=None, dropout=None):
+    """Apply a dense layer to ``inputs`` using ``nn.Linear``.
+
+    Args:
+        inputs (Tensor): Input tensor of shape ``[batch, in_features]``.
+        out_features (int): Number of output features.
+        activation (callable, optional): Activation function to apply.
+        dropout (float, optional): Dropout probability. If provided, ``nn.Dropout``
+            with ``p=dropout`` is applied after the activation.
+
+    Returns:
+        Tensor: Output tensor of shape ``[batch, out_features]``.
+    """
+    in_features = inputs.shape[-1]
+    layer = nn.Linear(in_features, out_features)
+    x = layer(inputs)
+    if activation is not None:
+        x = activation(x)
+    if dropout is not None:
+        x = nn.Dropout(p=dropout)(x)
+    return x
+
+
+def time_distributed_dense_layer(inputs, out_features, activation=None, dropout=None):
+    """Apply a dense layer to each time step of ``inputs``.
+
+    Reshapes ``inputs`` from ``[B, T, F]`` to ``[B*T, F]``, applies an
+    ``nn.Linear`` layer, then reshapes back to ``[B, T, out_features]``.
+
+    Args:
+        inputs (Tensor): Input tensor of shape ``[batch, time, features]``.
+        out_features (int): Number of output features.
+        activation (callable, optional): Activation function to apply.
+        dropout (float, optional): Dropout probability applied after activation.
+
+    Returns:
+        Tensor: Output tensor of shape ``[batch, time, out_features]``.
+    """
+    batch, time, in_features = inputs.shape
+    layer = nn.Linear(in_features, out_features)
+    x = inputs.reshape(batch * time, in_features)
+    x = layer(x)
+    if activation is not None:
+        x = activation(x)
+    if dropout is not None:
+        x = nn.Dropout(p=dropout)(x)
+    x = x.reshape(batch, time, out_features)
+    return x


### PR DESCRIPTION
## Summary
- add `torch_utils.py` with `dense_layer` and `time_distributed_dense_layer`
- switch `rnn.py` and `rnn_cell.py` to use the new torch-based helpers

## Testing
- `python -m py_compile torch_utils.py rnn.py rnn_cell.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a72771c8e48330be3dbc0e96242abb