### PR TITLE
Add PyTorch RNN free-run helper

### DIFF
--- a/pytorch_rnn_cell.py
+++ b/pytorch_rnn_cell.py
@@ -6,6 +6,8 @@ from torch import nn
 import torch.nn.functional as F
 from torch.distributions import MultivariateNormal, Bernoulli, Categorical
 
+from pytorch_rnn_ops import rnn_free_run
+
 
 @dataclass
 class LSTMAttentionCellState:
@@ -173,6 +175,31 @@ class LSTMAttentionCell(nn.Module):
         es = output[:, 2].long()
         is_eos = es == 1
         return torch.logical_or(final_char & is_eos, past_final_char)
+
+    def free_run(
+        self,
+        initial_state: LSTMAttentionCellState,
+        initial_input: torch.Tensor,
+        max_steps: int,
+    ) -> Tuple[torch.Tensor, LSTMAttentionCellState]:
+        """Generate a sequence by feeding predictions back into the cell.
+
+        Args:
+            initial_state: Starting state for the RNN cell.
+            initial_input: First input fed to the cell of shape ``[B, F]``.
+            max_steps: Maximum number of steps to unroll.
+
+        Returns:
+            A tuple ``(outputs, final_state)`` where ``outputs`` has shape
+            ``[T, B, F]``.
+        """
+
+        return rnn_free_run(
+            cell=self,
+            initial_state=initial_state,
+            initial_input=initial_input,
+            max_steps=max_steps,
+        )
 
     def _parse_parameters(self, gmm_params: torch.Tensor, eps: float = 1e-8, sigma_eps: float = 1e-4):
         splits = [

--- a/pytorch_rnn_ops.py
+++ b/pytorch_rnn_ops.py
@@ -1,0 +1,57 @@
+import torch
+from typing import Any, Tuple, List
+
+
+def rnn_free_run(
+    cell: Any,
+    initial_state: Any,
+    initial_input: torch.Tensor,
+    max_steps: int,
+) -> Tuple[torch.Tensor, Any]:
+    """Run ``cell`` in a free-running fashion.
+
+    At each step the cell's :py:meth:`output_function` is fed back as the input
+    for the next step. The loop terminates when ``max_steps`` is reached or when
+    the cell's :py:meth:`termination_condition` signals that all sequences in
+    the batch are finished.
+
+    Args:
+        cell: RNN cell with ``forward``, ``output_function`` and
+            ``termination_condition`` methods.
+        initial_state: Initial state for the cell.
+        initial_input: Tensor of shape ``[B, F]`` used as the first input.
+        max_steps: Maximum number of sampling steps to perform.
+
+    Returns:
+        Tuple containing ``outputs`` of shape ``[T, B, F]`` and the final cell
+        state.
+    """
+
+    state = initial_state
+    input_t = initial_input
+    outputs: List[torch.Tensor] = []
+
+    for _ in range(max_steps):
+        # Perform one step of the RNN
+        _, state = cell.forward(input_t, state)
+
+        # Produce the next input using the cell's output function
+        next_input = cell.output_function(state)
+        outputs.append(next_input)
+
+        # Check if all sequences have finished
+        if torch.all(cell.termination_condition(state)):
+            break
+
+        input_t = next_input
+
+    if outputs:
+        stacked_outputs = torch.stack(outputs, dim=0)
+    else:
+        stacked_outputs = torch.zeros(
+            (0, initial_input.size(0), initial_input.size(1)),
+            device=initial_input.device,
+        )
+
+    return stacked_outputs, state
+


### PR DESCRIPTION
## Summary
- Implement `rnn_free_run` for PyTorch to repeatedly step a cell until termination or max steps
- Expose new `free_run` method on `LSTMAttentionCell` to generate sequences using the helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a75f219bc88330bd99389b451a58ea